### PR TITLE
Add Ionic/Firebase watering reminder prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# test-push-noti
+# Watering Reminder Prototype
+
+This repository contains a minimal prototype for a watering reminder app built with Ionic and Angular using standalone components.
+
+## Getting Started
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Build the project (compiles TypeScript):
+
+```bash
+npm run build
+```
+
+3. Deploy `functions/` to Firebase if you want to use the Cloud Function skeleton.
+
+## Structure
+
+- `src/` contains the Ionic + Angular application.
+- `functions/` contains a Firebase Cloud Function that listens for new reminders and demonstrates how to send a notification via FCM.
+
+This prototype accepts a number of days, calculates the due date, stores a reminder in Firestore, and provides a placeholder Cloud Function for notifications.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,24 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+// Listens for new reminders and schedules a notification
+exports.scheduleReminder = functions.firestore
+  .document('reminders/{id}')
+  .onCreate(async (snap, context) => {
+    const data = snap.data();
+    const dueDate = data.dueDate.toDate();
+    const payload = {
+      notification: {
+        title: 'Water your plant',
+        body: `Reminder set for ${dueDate.toDateString()}`
+      }
+    };
+    // Here you could integrate with FCM or a third-party scheduler
+    // For prototype, send immediately if dueDate is in the past
+    if (dueDate <= new Date()) {
+      await admin.messaging().sendToTopic('reminders', payload);
+    } else {
+      // TODO: schedule message for future execution
+    }
+  });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "watering-reminder-app",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@angular/common": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@ionic/angular": "^7.0.0",
+    "@angular/fire": "^17.0.0",
+    "firebase": "^9.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0"
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ReminderService } from './reminder.service';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [IonicModule, CommonModule, FormsModule],
+  providers: [ReminderService],
+  template: `
+    <ion-app>
+      <ion-header>
+        <ion-toolbar color="primary">
+          <ion-title>Watering Reminder</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <form (ngSubmit)="setReminder()">
+          <ion-item>
+            <ion-label position="floating">Days until next watering</ion-label>
+            <ion-input type="number" [(ngModel)]="days" name="days" required></ion-input>
+          </ion-item>
+          <ion-button expand="block" type="submit" [disabled]="!days">Set Reminder</ion-button>
+        </form>
+      </ion-content>
+    </ion-app>
+  `
+})
+export class AppComponent {
+  days: number | undefined;
+
+  constructor(private reminderSvc: ReminderService) {}
+
+  setReminder() {
+    if (!this.days) return;
+    this.reminderSvc.createReminder(this.days);
+    this.days = undefined;
+  }
+}

--- a/src/app/reminder.service.ts
+++ b/src/app/reminder.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Firestore, collection, addDoc, Timestamp } from '@angular/fire/firestore';
+import { collectionData } from '@angular/fire/firestore';
+
+@Injectable()
+export class ReminderService {
+  constructor(private firestore: Firestore) {}
+
+  async createReminder(days: number) {
+    const dueDate = new Date();
+    dueDate.setDate(dueDate.getDate() + days);
+    await addDoc(collection(this.firestore, 'reminders'), {
+      dueDate: Timestamp.fromDate(dueDate),
+      created: Timestamp.now()
+    });
+  }
+
+  getReminders() {
+    return collectionData(collection(this.firestore, 'reminders'), { idField: 'id' });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,28 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, Routes } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+import { AppComponent } from './app/app.component';
+import { importProvidersFrom } from '@angular/core';
+import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
+import { provideFirestore, getFirestore } from '@angular/fire/firestore';
+
+const routes: Routes = [
+  { path: '', component: AppComponent }
+];
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideAnimations(),
+    provideRouter(routes),
+    importProvidersFrom(IonicModule.forRoot()),
+    provideFirebaseApp(() => initializeApp({
+      apiKey: 'YOUR_API_KEY',
+      authDomain: 'YOUR_AUTH_DOMAIN',
+      projectId: 'YOUR_PROJECT_ID',
+      messagingSenderId: 'YOUR_SENDER_ID',
+      appId: 'YOUR_APP_ID'
+    })),
+    provideFirestore(() => getFirestore())
+  ]
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": false,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Ionic with Angular standalone component boilerplate
- create ReminderService for saving due date to Firestore
- add a Firebase Cloud Function skeleton for push notifications
- document how to build the project

## Testing
- `npm run build` *(fails: cannot find Angular modules)*

------
https://chatgpt.com/codex/tasks/task_e_684775568564832e927022a6213cf1f9